### PR TITLE
Update config_automation.yml to point to dev base_ottr

### DIFF
--- a/config_automation.yml
+++ b/config_automation.yml
@@ -37,4 +37,4 @@ make-book-txt: true
 
 # What docker image should be used for rendering?
 # The default is jhudsl/base_ottr:main
-rendering-docker-image: 'jhudsl/base_ottr:main'
+rendering-docker-image: 'jhudsl/base_ottr:testNoTOC'


### PR DESCRIPTION
the dev base_ottr branch we're using installs a specific ottrpal branch that changes no toc rendering so that every link by default should open in a new tab. So I want to test rendering and inspect the output files to see if that's the case